### PR TITLE
Troca de MIMO para SISO

### DIFF
--- a/scratch/v2x_3gpp_small.cc
+++ b/scratch/v2x_3gpp_small.cc
@@ -540,7 +540,7 @@ int main(int argc, char* argv[])
 
     // Modo de transmissão (SISO [0], MIMO [1])
     Config::SetDefault("ns3::LteEnbRrc::DefaultTransmissionMode",
-        UintegerValue(1));
+        UintegerValue(0));
 
     /*------------------------- MÓDULOS LTE ----------------------*/
     Ptr<LteHelper> lteHelper = CreateObject<LteHelper>();


### PR DESCRIPTION
O cálculo que fiz, dos 18Gbps se aplica apenas quando a antena é SISO, portanto mudei aqui para termos uma ideia mais certa.
Colocando MIMO, aumenta-se a largura de banda do canal, o que não quero.